### PR TITLE
Fix buildvcs flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.19 AS builder
 WORKDIR /src/litefs-example
 COPY . .
-RUN go build -ldflags "-s -w -extldflags '-static'" -tags osusergo,netgo -o /usr/local/bin/litefs-example ./cmd/litefs-example
+RUN go build -buildvcs=false -ldflags "-s -w -extldflags '-static'" -tags osusergo,netgo -o /usr/local/bin/litefs-example ./cmd/litefs-example
 
 
 # Our final Docker image stage starts here.


### PR DESCRIPTION
This pull request adds the `-buildvcs=false` flag into `go build`. This may now be required because the `builder` stage in the Dockerfile is pinned to a minor version of Go (`1.19`) rather than a patch version (`1.19.6`).